### PR TITLE
Heal test for fms

### DIFF
--- a/src/main/resources/etc/json_file/network_service_descriptors/NetworkServiceDescriptor-sipp-real-fms-heal.json
+++ b/src/main/resources/etc/json_file/network_service_descriptors/NetworkServiceDescriptor-sipp-real-fms-heal.json
@@ -1,0 +1,195 @@
+{
+  "name":"SIPp with fm policy HEAL",
+  "vendor":"FOKUS",
+  "version":"1.0",
+  "vld":[
+    {
+      "name":"private"
+    }
+  ],
+  "vnfd":[
+    {
+      "name":"sipp-client",
+      "vendor":"FOKUS",
+      "version":"1.0",
+      "lifecycle_event":[
+        {
+          "event":"INSTANTIATE",
+          "lifecycle_events":[
+            "sipp_install.sh"
+          ]
+        },
+        {
+          "event":"CONFIGURE",
+          "lifecycle_events":[
+            "server_sipp_configure.sh"
+          ]
+        },
+        {
+          "event":"START",
+          "lifecycle_events":[
+            "sipp_client_start.sh"
+          ]
+        }
+      ],
+      "vdu":[
+        {
+          "vm_image":[
+            "ubuntu-14.04-server-cloudimg-amd64-disk1"
+          ],
+          "scale_in_out":1,
+          "vnfc":[
+            {
+              "connection_point":[
+                {
+                  "floatingIp":"random",
+                  "virtual_link_reference":"private",
+                  "interfaceId":0
+                }
+              ]
+            }
+          ],
+          "vimInstanceName":["vim-instance"]
+        }
+      ],
+      "configurations": {
+        "configurationParameters": [
+          {
+            "confKey": "SIPP_LENGTH",
+            "value": "0",
+            "description": "Controls the length (in milliseconds) of calls. More precisely, this controls the duration of 'pause' instructions in the scenario, if they do not have a 'milliseconds' section. Default value is 0."
+          },
+          {
+            "confKey": "SIPP_RATE",
+            "value": "10",
+            "description": "Set the call rate (in calls per seconds). Default is 10. If the -rp option is used, the call rate is calculated with the period in ms given by the user."
+          },
+          {
+            "confKey": "SIPP_RATE_PERIOD",
+            "value": "1000",
+            "description": "Specify the rate period in milliseconds for the call rate.  Default is 1 second.  This allows you to have n calls every m milliseconds (by using -r n -rp m). Example: -r 7 -rp 2000 ==> 7 calls every 2 seconds."
+          },
+          {
+            "confKey": "SIPP_RATE_MAX",
+            "value": "10",
+            "description": "If -rate_increase is set, then quit after the rate reaches this value. Example: -rate_increase 10 -max_rate 100 ==> increase calls by 10 until 100 cps is hit."
+          },
+          {
+            "confKey": "SIPP_RATE_INCREASE",
+            "value": "0",
+            "description": "Specify the rate increase every -fd seconds.  This allows you to increase the load for each independent logging period. Example: -rate_increase 10 -fd 10 ==> increase calls by 10 every 10 seconds."
+          },
+          {
+            "confKey": "SIPP_RTP_ECHO",
+            "value": "10",
+            "description": "Enable RTP echo. RTP/UDP packets received on port defined by -mp are echoed to their sender. RTP/UDP packets coming on this port + 2 are also echoed to their sender (used for sound and video echo)."
+          },
+          {
+            "confKey": "SIPP_TRANSPORT_MODE",
+            "value": "u1",
+            "description": "Set the transport mode: - u1: UDP with one socket (default), - un: UDP with one socket per call, - ui: UDP with one socket per IP address The IP addresses must be defined in the injection file. - t1: TCP with one socket, - tn: TCP with one socket per call, - l1: TLS with one socket, - ln: TLS with one socket per call, - c1: u1 + compression (only if compression plugin loaded), - cn: un + compression (only if compression plugin loaded)."
+          }
+        ],
+        "name": "sipp-configuration"
+      },
+      "virtual_link":[
+        {
+          "name":"private"
+        }
+      ],
+      "deployment_flavour":[
+        {
+          "flavour_key":"m1.small"
+        }
+      ],
+      "type":"client",
+      "endpoint":"generic",
+      "vnfPackageLocation":"https://github.com/openbaton/vnf-scripts.git"
+    },
+    {
+      "name":"sipp-server",
+      "vendor":"FOKUS",
+      "version":"1.0",
+      "lifecycle_event":[
+        {
+          "event":"INSTANTIATE",
+          "lifecycle_events":[
+            "sipp_install.sh"                    ]
+        },
+        {
+          "event":"HEAL",
+          "lifecycle_events":[
+            "heal.sh"                    ]
+        },
+        {
+          "event":"START",
+          "lifecycle_events":[
+            "sipp_server_start.sh"
+          ]
+        }
+      ],
+      "virtual_link":[
+        {
+          "name":"private"
+        }
+      ],
+      "vdu":[
+        {
+          "vm_image":[
+            "ubuntu-14.04-server-cloudimg-amd64-disk1"
+          ],
+          "scale_in_out":2,
+          "vnfc":[
+            {
+              "connection_point":[
+                {
+                  "floatingIp":"random",
+                  "virtual_link_reference":"private",
+                  "interfaceId":0
+                }
+              ]
+            }
+          ],
+          "vimInstanceName":["vim-instance"],
+          "monitoring_parameter":[
+            "net.udp.listen[5060]"
+          ],
+          "fault_management_policy":[
+            {
+              "name":"Heal SIPp Server down",
+              "isVNFAlarm":true,
+              "criteria":[
+                {
+                  "parameter_ref":"net.udp.listen[5060]",
+                  "function":"last()",
+                  "vnfc_selector":"at_least_one",
+                  "comparison_operator":"=",
+                  "threshold":"0"
+                }
+              ],
+              "severity":"CRITICAL",
+              "period":5
+            }
+          ]
+        }
+      ],
+      "deployment_flavour":[
+        {
+          "flavour_key":"m1.small"
+        }
+      ],
+      "type":"server",
+      "endpoint":"generic",
+      "vnfPackageLocation":"https://github.com/openbaton/vnf-scripts.git"
+    }
+  ],
+  "vnf_dependency":[
+    {
+      "source":"sipp-server",
+      "target":"sipp-client",
+      "parameters":[
+        "private"
+      ]
+    }
+  ]
+}

--- a/src/main/resources/etc/scripts/kill-sipp-server-and-wait-till-it-is-healed.sh
+++ b/src/main/resources/etc/scripts/kill-sipp-server-and-wait-till-it-is-healed.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Kill the running sipp server
+sudo pkill screen
+echo "SIPp server killed"
+
+timeout=300
+seconds=0
+until [ $(ps aux | grep -v grep | grep -v "kill-sipp-server-and-" | grep sipp | wc -l) -gt 1 ]
+do
+	if [ $seconds -ge $timeout ]
+		then
+			exit 1
+		fi
+	echo "waiting for healing (since $seconds seconds).. timeout is $timeout seconds"
+	((seconds+=5))
+	sleep 5
+done
+
+echo "SIPp server healed"

--- a/src/main/resources/etc/scripts/sipp-running.sh
+++ b/src/main/resources/etc/scripts/sipp-running.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+sipp_count=$(ps -aux | grep -v grep | grep -v "sipp-running" | grep sipp | wc -l)
+if [ $sipp_count -lt 1 ]
+then
+  exit 1
+else
+  exit 0
+fi
+

--- a/src/main/resources/integration-test-scenarios/scenario-real-sipp-fms-heal.ini
+++ b/src/main/resources/integration-test-scenarios/scenario-real-sipp-fms-heal.ini
@@ -1,0 +1,77 @@
+;This scenario deploys a sipp client and server example using the generic-vnfm. Then a failure is injected and the fault management system will heal the service perfoming the HEAL action
+
+[it]
+;set the maximum time (in seconds) of the Integration test. e.g. 10 min = 600 seconds
+max-integration-test-time = 800
+;set the maximum number of concurrent successors (max number of active child threads)
+max-concurrent-successors = 10
+
+;vimInstance-create
+[it/vim-c-1]
+class-name = VimInstanceCreate
+name-file = real-vim.json
+successor-remover = vim-d-1
+
+[it/vim-c-1/vim-d-1]
+class-name = VimInstanceDelete
+
+;nsd-create
+[it/vim-c-1/nsd-c-1]
+class-name = NetworkServiceDescriptorCreate
+num_instances = 1
+successor-remover = nsd-d-1
+name-file = NetworkServiceDescriptor-sipp-real-fms-heal.json
+
+;nsd-delete
+[it/vim-c-1/nsd-c-1/nsd-d-1]
+class-name = NetworkServiceDescriptorDelete
+
+;nsr-create
+[it/vim-c-1/nsd-c-1/nsr-c-1]
+class-name = NetworkServiceRecordCreate
+num_instances = 1
+
+;nsr-wait for creation
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1]
+class-name = NetworkServiceRecordWait
+;the default timeout is 5 seconds
+timeout = 600
+action = INSTANTIATE_FINISH
+
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1/gst-1]
+class-name = GenericServiceTester
+vnf-type = client
+script-1 = sipp-running.sh
+user-name = ubuntu
+vm-scripts-path = /home/ubuntu
+
+
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1/gst-1/gst-2]
+class-name = GenericServiceTester
+vnf-type = server
+net-name = private
+script-1 = sipp-running.sh
+user-name = ubuntu
+vm-scripts-path = /home/ubuntu
+
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1/gst-1/gst-2/gst-3]
+class-name = GenericServiceTester
+vnf-type = server
+net-name = private
+script-1 = kill-sipp-server-and-wait-till-it-is-healed.sh
+user-name = ubuntu
+vm-scripts-path = /home/ubuntu
+
+;nsr-wait for deletion
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1/gst-1/gst-2/gst-3/nsr-w-2]
+class-name = NetworkServiceRecordWait
+;the default timeout is 5 seconds
+timeout = 360
+action = RELEASE_RESOURCES_FINISH
+
+;nsr-delete
+[it/vim-c-1/nsd-c-1/nsr-c-1/nsr-w-1/gst-1/gst-2/gst-3/nsr-d-1]
+class-name = NetworkServiceRecordDelete
+
+
+


### PR DESCRIPTION
Introduce a test for the Fault Management System. These are the steps:
1. Create the SIPp client-server network service
2. Test if it is running properly
3. Kill the SIPp server
4. Wait till it is restored by the FMS
5. Conclude the test cleaning the environment

Start the test scenario:
./integration-tests.sh start scenario-real-sipp-fms-heal.ini